### PR TITLE
operate on team when delete a registered user and approve new member

### DIFF
--- a/open-hackathon-client/src/client/static/js/views/oh.manage.organizers.js
+++ b/open-hackathon-client/src/client/static/js/views/oh.manage.organizers.js
@@ -28,7 +28,7 @@
 
     var currentHackathon = oh.comm.getCurrentHackathon();
 
-    function bindAzurecertList() {
+    function bindOrganizerList() {
         var list = $('#organizerlist');
         oh.api.admin.hackathon.get({
             header: {hackathon_name: currentHackathon}
@@ -91,7 +91,7 @@
             if (data.error) {
                 oh.comm.alert('错误', data.error.friendly_message);
             } else {
-                bindAzurecertList();
+                bindOrganizerList();
                 resetForm();
             }
         });
@@ -102,7 +102,7 @@
             if (data.error) {
                 oh.comm.alert('错误', data.error.friendly_message);
             } else {
-                bindAzurecertList();
+                bindOrganizerList();
                 resetForm();
             }
         });
@@ -113,7 +113,7 @@
             if (data.error) {
                 oh.comm.alert('错误', data.error.friendly_message);
             } else {
-                bindAzurecertList();
+                bindOrganizerList();
             }
         });
     }
@@ -168,7 +168,7 @@
             language: 'zh'
         });
 
-        bindAzurecertList();
+        bindOrganizerList();
     }
 
     $(function () {

--- a/open-hackathon-server/src/hackathon/hack/register_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/register_manager.py
@@ -140,17 +140,16 @@ class RegisterManager(Component):
             return bad_request("id not invalid")
         try:
             register = self.db.find_first_object_by(UserHackathonRel, id = args['id'])
+            user = register.user
             if register is not None:
                 self.db.delete_object(register)
                 hackathon = self.hackathon_manager.get_hackathon_by_id(register.hackathon_id)
                 self.__update_register_stat(hackathon)
 
-                user = self.user_manager.get_user_by_id(register.user_id)
-                if not user:
-                    return ok("this registered user is not found!")
                 team = self.team_manager.get_team_by_user_and_hackathon(user, hackathon)
                 if not team:
-                    return ok("team of this registered user is not found!")
+                    self.log.warn("team of this registered user is not found!")
+                    return ok()
                 self.team_manager.quit_team_forcedly(team, user)
 
             return ok()

--- a/open-hackathon-server/src/hackathon/hack/register_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/register_manager.py
@@ -133,6 +133,9 @@ class RegisterManager(Component):
             return internal_server_error("fail to  update register")
 
     def delete_registration(self, args):
+        """
+        Delete the registration of a user in a hackathon, also do operation on the user's team.
+        """
         if "id" not in args:
             return bad_request("id not invalid")
         try:
@@ -141,6 +144,15 @@ class RegisterManager(Component):
                 self.db.delete_object(register)
                 hackathon = self.hackathon_manager.get_hackathon_by_id(register.hackathon_id)
                 self.__update_register_stat(hackathon)
+
+                user = self.user_manager.get_user_by_id(register.user_id)
+                if not user:
+                    return not_found("this registered user is not found!")
+                team = self.team_manager.get_team_by_user_and_hackathon(user, hackathon)
+                if not team:
+                    return not_found("team of this registered user is not found!")
+                self.team_manager.quit_team_forcedly(team.id, user)
+
             return ok()
         except Exception as ex:
             self.log.error(ex)

--- a/open-hackathon-server/src/hackathon/hack/register_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/register_manager.py
@@ -147,11 +147,11 @@ class RegisterManager(Component):
 
                 user = self.user_manager.get_user_by_id(register.user_id)
                 if not user:
-                    return not_found("this registered user is not found!")
+                    return ok("this registered user is not found!")
                 team = self.team_manager.get_team_by_user_and_hackathon(user, hackathon)
                 if not team:
-                    return not_found("team of this registered user is not found!")
-                self.team_manager.quit_team_forcedly(team.id, user)
+                    return ok("team of this registered user is not found!")
+                self.team_manager.quit_team_forcedly(team, user)
 
             return ok()
         except Exception as ex:

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -219,7 +219,8 @@ class TeamManager(Component):
         # here we don't check whether the operator has the permission,
         members = self.db.find_all_objects_by(UserTeamRel, team_id=team.id, status=TeamMemberStatus.Approved)
         if not members or len(members) == 0:
-            return ok("this team doesn't have any members")
+            self.log.warn("this team doesn't have any members")
+            return ok()
         member_users = [m.user for m in members]
 
         num_team_members = len(member_users)

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -293,14 +293,6 @@ class TeamManager(Component):
         if rel.user_id == team.leader_id:
             return precondition_failed("cannot update status of team leader")
 
-        # check if the user is already in this team.
-        members = self.db.find_all_objects_by(UserTeamRel, team_id=team.id, status=TeamMemberStatus.Approved)
-        if not members or len(members) == 0:
-            return not_found("this team doesn't have any members")
-        member_users_id = [m.user.id for m in members]
-        if rel.user_id in member_users_id:
-            return not_found("the user is already in this team.")
-
         if status == TeamMemberStatus.Approved:
             # disable previous team first
             self.db.delete_all_objects_by(UserTeamRel,

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -298,6 +298,14 @@ class TeamManager(Component):
         if rel.user_id == team.leader_id:
             return precondition_failed("cannot update status of team leader")
 
+        # check if the user is already in this team.
+        members = self.db.find_all_objects_by(UserTeamRel, team_id=team.id, status=TeamMemberStatus.Approved)
+        if not members or len(members) == 0:
+            return not_found("this team doesn't have any members")
+        member_users_id = [m.user.id for m in members]
+        if rel.user_id in member_users_id:
+            return not_found("the user is already in this team.")
+
         if status == TeamMemberStatus.Approved:
             # disable previous team first
             self.db.delete_all_objects_by(UserTeamRel,

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -206,7 +206,7 @@ class TeamManager(Component):
 
     def quit_team_forcedly(self, team_id, user):
         """
-        The operator(team leader, admin or superadmin) forces a user(team leader or other members) to quit a team.
+        The operator(admin or superadmin) forces a user(team leader or other members) to quit a team.
         If the user is the only member of the team, the team will be deleted.
         Else if the user is the leader of a team with several members, the team will be decomposed into several
         new teams.

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -223,7 +223,7 @@ class TeamManager(Component):
 
         members = self.db.find_all_objects_by(UserTeamRel, team_id=team.id, status=TeamMemberStatus.Approved)
         if not members or len(members) == 0:
-            return not_found("team_id: " + team.id + " doesn't have any members")
+            return not_found("this team doesn't have any members")
         member_users = [m.user for m in members]
 
         num_team_members = len(member_users)
@@ -238,10 +238,10 @@ class TeamManager(Component):
             else:
                 self.db.delete_all_objects_by(UserTeamRel, user_id=user.id, team_id=team_id)
         elif num_team_members == 1:
-                self.db.delete_all_objects_by(UserTeamRel, team_id=team.id)
-                self.db.delete_object(team)
+            self.db.delete_all_objects_by(UserTeamRel, team_id=team.id)
+            self.db.delete_object(team)
         else:
-            return not_found("team doesn't have any members")
+            return not_found("this team doesn't have any members")
 
         return ok()
 

--- a/open-hackathon-server/src/hackathon/hack/team_manager.py
+++ b/open-hackathon-server/src/hackathon/hack/team_manager.py
@@ -204,7 +204,7 @@ class TeamManager(Component):
 
         return ok()
 
-    def quit_team_forcedly(self, team_id, user):
+    def quit_team_forcedly(self, team, user):
         """
         The operator(admin or superadmin) forces a user(team leader or other members) to quit a team.
         If the user is the only member of the team, the team will be deleted.
@@ -215,15 +215,11 @@ class TeamManager(Component):
         :rtype: bool
         :return: if dismiss success, return ok. if not ,return bad request.
         """
-        team = self.__get_team_by_id(team_id)
-        if not team:
-            return not_found("team not exists")
 
         # here we don't check whether the operator has the permission,
-
         members = self.db.find_all_objects_by(UserTeamRel, team_id=team.id, status=TeamMemberStatus.Approved)
         if not members or len(members) == 0:
-            return not_found("this team doesn't have any members")
+            return ok("this team doesn't have any members")
         member_users = [m.user for m in members]
 
         num_team_members = len(member_users)
@@ -236,12 +232,11 @@ class TeamManager(Component):
                     if u.id != user.id:
                         self.create_default_team(hackathon, u)
             else:
-                self.db.delete_all_objects_by(UserTeamRel, user_id=user.id, team_id=team_id)
-        elif num_team_members == 1:
+                self.db.delete_all_objects_by(UserTeamRel, user_id=user.id, team_id=team.id)
+        else:
+            #num_team_members == 1
             self.db.delete_all_objects_by(UserTeamRel, team_id=team.id)
             self.db.delete_object(team)
-        else:
-            return not_found("this team doesn't have any members")
 
         return ok()
 


### PR DESCRIPTION
fix the problem of operations on team when delete a registered user.
fix the problem of double click 'approval' of new member to join the team will not be approved and would delete the new member in mistake. 