### PR TITLE
team award refactored - awards api

### DIFF
--- a/open-hackathon-server/src/hackathon/views/resources.py
+++ b/open-hackathon-server/src/hackathon/views/resources.py
@@ -726,10 +726,12 @@ class AdminHackathonOnLineResource(HackathonResource):
     def post(self):
         return hackathon_manager.hackathon_online(g.hackathon)
 
+
 class AdminHackathonOffLineResource(HackathonResource):
     @admin_privilege_required
     def post(self):
         return hackathon_manager.hackathon_offline(g.hackathon)
+
 
 class AdminHackathonNoticeResource(HackathonResource):
     @admin_privilege_required


### PR DESCRIPTION
NOTE:

we cannot add reason when granting awards beacause of using uuid list as `Team.awards` field