### PR TITLE
Restart stopped container (only support hosted-docker, not for alauda-docker or azure-window)

### DIFF
--- a/open-hackathon-client/src/client/static/js/manage.controller.js
+++ b/open-hackathon-client/src/client/static/js/manage.controller.js
@@ -1495,7 +1495,7 @@ angular.module('oh.controllers', [])
     }
 
   })
-  .controller('monitorController', function($rootScope, $scope, $stateParams, api) {
+  .controller('monitorController', function($rootScope, $scope, $stateParams, $window, $timeout, api, dialog) {
     $scope.$emit('pageName', 'ADVANCED_SETTINGS.ENVIRONMENTAL_MONITOR');
 
     $scope.data = {
@@ -1528,6 +1528,31 @@ angular.module('oh.controllers', [])
 
     $scope.deleteExperiment = function(experiment) {
       showTip('tip-danger', "暂时不支持删除操作");
+    }
+
+    $scope.refreshExperiment = function(experiment) {
+      dialog.confirm({
+        title: '提示',
+        body: '是否尝试启动已停止的环境/容器?'
+      }).then(function() {
+        api.admin.experiment.put({
+          body: {
+            experiment_id: experiment.id
+          },
+          header: {
+            hackathon_name: $stateParams.name
+          }
+        }).then(function(data) {
+          if (data.error)
+            showTip('tip-danger', data.error.friendly_message);
+          else {
+            showTip('tip-success', '操作成功! 启动环境/容器需要一定时间，三秒后自动刷新查看最新状态。');
+            $timeout(function() {
+              $window.location.reload()
+            }, 3000);
+          }
+        });
+      });
     }
 
     $scope.searchExperiment = function() {

--- a/open-hackathon-client/src/client/static/partials/manage/monitor.html
+++ b/open-hackathon-client/src/client/static/partials/manage/monitor.html
@@ -29,6 +29,9 @@
           <td>{{experiment.create_time | date:'yyyy-MM-dd HH:mm:ss'}}</td>
           <td>{{experiment.virtual_environments | joinVMs}}</td>
           <td class="option">
+            <a class="btn btn-success btn-sm" ng-click="refreshExperiment(experiment)">
+              <i class="fa fa-refresh"></i>
+            </a>
             <a class="btn btn-info btn-sm" ng-click="updateExperiment(experiment)">
               <i class="fa fa-edit"></i>
             </a>

--- a/open-hackathon-server/src/hackathon/expr/expr_starter.py
+++ b/open-hackathon-server/src/hackathon/expr/expr_starter.py
@@ -115,7 +115,7 @@ class ExprStarter(Component):
         ve.status = VEStatus.STOPPED
 
         if all(ve.status == VEStatus.STOPPED for ve in expr.virtual_environments):
-            expr.status = VEStatus.STOPPED
+            expr.status = EStatus.STOPPED
             expr.save()
 
     def _on_virtual_environment_unexpected_error(self, context):

--- a/open-hackathon-server/src/hackathon/views/resources.py
+++ b/open-hackathon-server/src/hackathon/views/resources.py
@@ -265,7 +265,7 @@ class UserHackathonLikeResource(HackathonResource):
 
 class UserExperimentResource(HackathonResource, Component):
     def get(self):
-        return expr_manager.get_expr_status(self.context().id)
+        return expr_manager.get_expr_status_and_start(self.context().id)
 
     @token_required
     def post(self):
@@ -587,6 +587,10 @@ class AdminExperimentResource(HackathonResource):
             return bad_request('template name name invalid')
         template_name = args['name']
         return expr_manager.start_expr(g.user, template_name, g.hackathon.name)
+
+    @admin_privilege_required
+    def put(self):
+        return expr_manager.restart_stopped_expr(self.context().experiment_id)
 
     @admin_privilege_required
     def delete(self):

--- a/open-hackathon-server/src/hackathon/views/resources.py
+++ b/open-hackathon-server/src/hackathon/views/resources.py
@@ -265,7 +265,7 @@ class UserHackathonLikeResource(HackathonResource):
 
 class UserExperimentResource(HackathonResource, Component):
     def get(self):
-        return expr_manager.get_expr_status_and_start(self.context().id)
+        return expr_manager.get_expr_status_and_confirm_starting(self.context().id)
 
     @token_required
     def post(self):

--- a/open-hackathon-server/src/hackathon/views/schema/AdminExperimentResource
+++ b/open-hackathon-server/src/hackathon/views/schema/AdminExperimentResource
@@ -1,0 +1,16 @@
+{
+  "AdminExperimentResource": {
+    "put": {
+      "input": {
+        "description": "restart stopped experiment",
+        "type": "object",
+        "properties": {
+          "experiment_id": {
+            "description": "object_id of experiment",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. 用户连接终端时会检测docker状态，如果是stopped，则重新启动hosted-docker
2. 在管理页面能获取到docker的真实状态，而且增加重新启动docker的按钮